### PR TITLE
Distinguish bot when emitting self

### DIFF
--- a/libraries/client.js
+++ b/libraries/client.js
@@ -663,7 +663,7 @@ client.prototype.action = function(channel, message) {
             self.logger.action('[' + utils.addHash(channel).toLowerCase() + '] ' + self.myself + ': ' + message);
         }
         if (self.emitSelf && self.selfData[utils.addHash(channel).toLowerCase()]) {
-            self.emit('action', utils.addHash(channel).toLowerCase(), self.selfData[utils.addHash(channel).toLowerCase()], message);
+            self.emit('action', utils.addHash(channel).toLowerCase(), self.selfData[utils.addHash(channel).toLowerCase()], message, true);
         }
         deferred.resolve(true);
     } else { deferred.resolve(false); }
@@ -918,7 +918,7 @@ client.prototype.say = function(channel, message) {
                 self.logger.chat('[' + utils.addHash(channel).toLowerCase() + '] ' + self.myself + ': ' + message);
             }
             if (self.emitSelf && self.selfData[utils.addHash(channel).toLowerCase()]) {
-                self.emit('chat', utils.addHash(channel).toLowerCase(), self.selfData[utils.addHash(channel).toLowerCase()], message);
+                self.emit('chat', utils.addHash(channel).toLowerCase(), self.selfData[utils.addHash(channel).toLowerCase()], message, true);
             }
             deferred.resolve(true);
         } else {


### PR DESCRIPTION
When the option "emitSelf" is true, there's no clear way to distinguish the bot from otherwise. (Say the account runs on the same account as the owner of the bot or as another bot) Simply passing a fourth argument to the event listeners as "from self" should be enough.

```
client.addListener('chat', function(channel, user, text, fromSelf) {
    console.log('This message was', fromSelf ? '' : 'not', 'from me.');
});
```
